### PR TITLE
Crash if there's an error from the amqp container.

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -24,6 +24,7 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const probe = require('kube-probe');
 const rhea = require('rhea');
+const cluster = require('cluster');
 
 // AMQP
 
@@ -93,7 +94,9 @@ const opts = {
 };
 
 container.on('error', err => {
-  console.log(err);
+  console.error(err);
+  console.error(`Exiting worker with status 100`);
+  process.exit(100);
 });
 
 console.log(`${id}: Attempting to connect to AMQP messaging service at ${amqpHost}:${amqpPort}`);

--- a/frontend/bin/www
+++ b/frontend/bin/www
@@ -24,30 +24,47 @@
  * Module dependencies.
  */
 
-const app = require('../app');
+const cluster = require('cluster');
 const debug = require('debug')('nodejs-messaging-work-queue-frontend:server');
 const http = require('http');
+var server;
+var port;
 
-/**
- * Get port from environment and store in Express.
- */
+if (cluster.isMaster) {
+  console.log('Forking worker from master');
+  cluster.fork();
+  cluster.on('exit', function(worker, code, signal) {
+    console.log('Worker %d died with code/signal %s', worker.process.pid, signal || code)
+    if (code === 100) {
+      console.log('Restarting worker in 5 seconds due to exit code 100 (amqp connection related)...');
+      setTimeout(() => {
+        cluster.fork();
+      }, 5000);
+    }
+  });
+} else {
+  const app = require('../app');
+  /**
+   * Get port from environment and store in Express.
+   */
 
-const port = normalizePort(process.env.PORT || '8080');
-app.set('port', port);
+  port = normalizePort(process.env.PORT || '8080');
+  app.set('port', port);
 
-/**
- * Create HTTP server.
- */
+  /**
+   * Create HTTP server.
+   */
 
-const server = http.createServer(app);
+  server = http.createServer(app);
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+  /**
+   * Listen on provided port, on all network interfaces.
+   */
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+  server.listen(port);
+  server.on('error', onError);
+  server.on('listening', onListening);
+}
 
 /**
  * Normalize a port into a number, string, or false.


### PR DESCRIPTION
This ensures the app tries to reconnect cleanly until the
worker-queue-requests exists.