### PR TITLE
Bump for "Use connections default sender instead of 'open_sender'"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
    "name": "nodejs-messaging-work-queue-frontend",
-   "version": "3.0.0",
+   "version": "3.0.1",
    "description": "A sample Node.js app that sends requests",
    "license": "Apache-2.0",
    "scripts": {


### PR DESCRIPTION
## Motivation
Bump for https://github.com/integr8ly/nodejs-messaging-work-queue/pull/9
