### PR TITLE
remove trailing slash from keycloak auth url

### DIFF
--- a/frontend/lib/keycloak.js
+++ b/frontend/lib/keycloak.js
@@ -12,6 +12,9 @@ exports.getKeycloakInstance = function (store) {
 
   if (!kcInstance && KEYCLOAK_CONFIG) {
     log.info('Keycloak config was detected. Using keycloak for authentication')
+    // Keycloak 7.4 seems to have appended a trailing slash to this value which upsets keycloak-connect,
+    // this removes any trailing slashes
+    KEYCLOAK_CONFIG['auth-server-url'] = KEYCLOAK_CONFIG['auth-server-url'].replace(/\/*$/, "")
     kcInstance = new Keycloak({ store }, KEYCLOAK_CONFIG)
   }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
    "name": "order-entry-ui",
-   "version": "5.0.0",
+   "version": "6.0.0",
    "description": "A Node.js application that serves a frontend that allows users to place orders. Orders are sent via AMQP to a queue.",
    "license": "Apache-2.0",
    "scripts": {


### PR DESCRIPTION
## Motivation
RHSSO 7.4 adds a trailing slash to the auth url

## What
remove the added trailing slash

## Why
Auth is not working with the trailing slash

## How
a regex 

## Verification Steps
1. deploy from master with a keycloak_config with an auth-server-url with a trailing slash
2. this will not allow oauth
3. deploy from this branch
4. oauth with function

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

